### PR TITLE
Summoning Eye alert

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -45,6 +45,7 @@ public class PlayerListener {
 
     private boolean sentUpdate = false;
     private long lastWorldJoin = -1;
+    private long lastScreenOpen = -1;
     private long lastBoss = -1;
     private int magmaTick = 1;
     private int timerTick = 1;
@@ -266,9 +267,14 @@ public class PlayerListener {
                             sentUpdate = true;
                         }
 
-                        if (main.getConfigValues().isEnabled(Feature.ITEM_PICKUP_LOG) && mc.currentScreen == null
-                        && main.getPlayerListener().didntRecentlyJoinWorld()) {
-                            main.getInventoryUtils().getInventoryDifference(p.inventory.mainInventory);
+                        if (mc.currentScreen != null) {
+                            lastScreenOpen = System.currentTimeMillis();
+                        }
+                        else {
+                            if (main.getConfigValues().isEnabled(Feature.ITEM_PICKUP_LOG)
+                                    && main.getPlayerListener().didntRecentlyJoinWorld()) {
+                                main.getInventoryUtils().getInventoryDifference(p.inventory.mainInventory);
+                            }
                         }
                     }
 
@@ -514,6 +520,10 @@ public class PlayerListener {
 
     public boolean didntRecentlyJoinWorld() {
         return System.currentTimeMillis() - lastWorldJoin > 3000;
+    }
+
+    public boolean didntRecentlyCloseScreen() {
+        return System.currentTimeMillis() - lastScreenOpen > 550;
     }
 
     public enum GUIType {

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
@@ -164,6 +164,8 @@ public class EnumUtils {
     public enum Location {
         ISLAND("Your Island"),
         BLAZING_FORTRESS("Blazing Fortress"),
+        THE_END("The End"),
+        DRAGONS_DEN("Dragon's Den"),
         VILLAGE("Village"),
         AUCTION_HOUSE("Auction House");
 

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/Feature.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/Feature.java
@@ -58,7 +58,9 @@ public enum Feature {
     BACKPACK_STYLE(-1, Message.SETTING_BACKPACK_STYLE),
     TEXT_STYLE(-1, Message.SETTING_TEXT_STYLE),
     NEXT_PAGE(-1, Message.SETTING_NEXT_PAGE),
-    PREVIOUS_PAGE(-1, Message.SETTING_PREVIOUS_PAGE);
+    PREVIOUS_PAGE(-1, Message.SETTING_PREVIOUS_PAGE)
+    //TODO: Add Summoning Eye Alert Feature
+    ;
 
     private int id;
     private Message message;

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/InventoryUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/InventoryUtils.java
@@ -121,12 +121,12 @@ public class InventoryUtils {
                 }
 
                 // Summoning Eye alert
-                if (main.getConfigValues().isEnabled(Feature.ITEM_PICKUP_LOG) //TODO: Change to new Summoning Eye Alert Feature
+                if (main.getConfigValues().isEnabled(Feature.ITEM_PICKUP_LOG) //TODO: Possibly change to new Summoning Eye Alert Setting
                         && diff.getAmount() == 1 && diff.getDisplayName().equals(SUMMONING_EYE_DISPLAY_NAME)
                         && main.getUtils().isLocationTheEndOrDragonsNest()
                         && main.getPlayerListener().didntRecentlyCloseScreen()){
                     main.getUtils().playSound("random.orb", 0.5);
-                    main.getRenderListener().setTitleFeature(Feature.FULL_INVENTORY_WARNING);
+                    main.getRenderListener().setTitleFeature(Feature.FULL_INVENTORY_WARNING); //TODO: Change to new Summoning Eye Alert Feature
                     new Timer().schedule(new TimerTask() {
                         @Override
                         public void run() {

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/InventoryUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/InventoryUtils.java
@@ -14,6 +14,11 @@ import java.util.*;
 public class InventoryUtils {
 
     /**
+     * Display name of the Summoning Eye item
+     */
+    private static final String SUMMONING_EYE_DISPLAY_NAME = "\u00A75Summoning Eye";
+
+    /**
      * Display name of the Quiver Arrow item
      */
     private static final String QUIVER_ARROW_DISPLAY_NAME = "\u00A78Quiver Arrow";
@@ -113,6 +118,21 @@ public class InventoryUtils {
                     itemPickupLog.get(diff.getDisplayName()).add(diff.getAmount());
                 } else {
                     itemPickupLog.put(diff.getDisplayName(), diff);
+                }
+
+                // Summoning Eye alert
+                if (main.getConfigValues().isEnabled(Feature.ITEM_PICKUP_LOG) //TODO: Change to new Summoning Eye Alert Feature
+                        && diff.getAmount() == 1 && diff.getDisplayName().equals(SUMMONING_EYE_DISPLAY_NAME)
+                        && main.getUtils().isLocationTheEndOrDragonsNest()
+                        && main.getPlayerListener().didntRecentlyCloseScreen()){
+                    main.getUtils().playSound("random.orb", 0.5);
+                    main.getRenderListener().setTitleFeature(Feature.FULL_INVENTORY_WARNING);
+                    new Timer().schedule(new TimerTask() {
+                        @Override
+                        public void run() {
+                            main.getRenderListener().setTitleFeature(null);
+                        }
+                    }, main.getConfigValues().getWarningSeconds() * 1000);
                 }
             }
         }

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
@@ -467,6 +467,10 @@ public class Utils {
         return location;
     }
 
+    public boolean isLocationTheEndOrDragonsNest(){
+        return location == EnumUtils.Location.THE_END || location == EnumUtils.Location.DRAGONS_DEN;
+    }
+
     public boolean isOnSkyblock() {
         return onSkyblock;
     }


### PR DESCRIPTION
Adds an alert when the player obtains a Summoning Eye drop from a Zealot in the End.

It purposefully evades activating the alert when a summoning eye is moved to the inventory from a backpack or enderchest, by checking to see if an inventory screen was closed in the last half second.

Sorry but I couldn't figure out the Feature system you got in place, so I left TODOs in place where I simply copied the existing Full Inventory alert message, and where I check for the item pickup log setting.

I wanted to contribute to the mod, Your codebase is fun to work in, I hope you like my code :)