### PR TITLE
Fixed locked slots w/ beacon inventories opened

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/mixins/MixinGuiBeacon.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/mixins/MixinGuiBeacon.java
@@ -1,0 +1,32 @@
+package codes.biscuit.skyblockaddons.mixins;
+
+import codes.biscuit.skyblockaddons.SkyblockAddons;
+import codes.biscuit.skyblockaddons.utils.Feature;
+import net.minecraft.client.gui.inventory.GuiBeacon;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.*;
+import org.spongepowered.asm.mixin.Mixin;
+
+
+@Mixin(GuiBeacon.class)
+public abstract class MixinGuiBeacon extends GuiContainer {
+
+    public MixinGuiBeacon(Container inventorySlotsIn) {
+        super(inventorySlotsIn);
+    }
+
+    @Override
+    protected void handleMouseClick(Slot slotIn, int slotId, int clickedButton, int clickType) {
+        SkyblockAddons main = SkyblockAddons.getInstance();
+        if (slotIn != null && main.getConfigValues().isEnabled(Feature.LOCK_SLOTS) &&
+                main.getUtils().isOnSkyblock()) {
+            int slotNum = slotIn.slotNumber;
+            slotNum+=8;
+            if (slotNum > 8 && main.getConfigValues().getLockedSlots().contains(slotNum)) {
+                main.getUtils().playSound("note.bass", 0.5);
+                return;
+            }
+        }
+        super.handleMouseClick(slotIn, slotId, clickedButton, clickType);
+    }
+}

--- a/src/main/java/codes/biscuit/skyblockaddons/mixins/MixinGuiContainer.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/mixins/MixinGuiContainer.java
@@ -214,6 +214,9 @@ public class MixinGuiContainer extends GuiScreen {
         } else if (container instanceof ContainerFurnace) {
             slotNum += 6;
             if (slotNum < 9) skipSlot = true;
+        } else if (container instanceof ContainerBeacon) {
+            slotNum += 8;
+            if (slotNum < 9) skipSlot = true;
         }
         main.getUtils().setLastHoveredSlot(slotNum);
         if (!skipSlot && theSlot != null && main.getConfigValues().isEnabled(Feature.LOCK_SLOTS) &&
@@ -243,6 +246,9 @@ public class MixinGuiContainer extends GuiScreen {
                 if (slotNum < 9) return;
             } else if (container instanceof ContainerFurnace) {
                 slotNum += 6;
+                if (slotNum < 9) return;
+            } else if (container instanceof ContainerBeacon) {
+                slotNum += 8;
                 if (slotNum < 9) return;
             }
             if (main.getConfigValues().getLockedSlots().contains(slotNum)) {

--- a/src/main/resources/mixins.skyblockaddons.json
+++ b/src/main/resources/mixins.skyblockaddons.json
@@ -19,6 +19,7 @@
     "MixinRendererLivingEntity",
     "MixinGuiHopper",
     "MixinGuiDispenser",
-    "MixinGuiFurnace"
+    "MixinGuiFurnace",
+    "MixinGuiBeacon"
   ]
 }


### PR DESCRIPTION
Previously, the wrong slots were locked. Here are results with changes:

![image](https://user-images.githubusercontent.com/8540562/65196838-b79aad00-da35-11e9-9679-c181f180f96b.png)
