### PR TITLE
Fallback to message key instead of empty string in case of missing translation 

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/utils/Message.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/Message.java
@@ -170,7 +170,7 @@ public enum Message {
             }
         } catch (NullPointerException ex) { // In case I messed up some translation or something.
             ex.printStackTrace();
-            text = "";
+            text = memberName;
         }
         return text;
     }


### PR DESCRIPTION
It makes a lot more sense